### PR TITLE
Significantly improve audio quality when exporting to mp3

### DIFF
--- a/ospeak/cli.py
+++ b/ospeak/cli.py
@@ -25,7 +25,9 @@ def stream_and_play(
     if speak:
         play(audio)
     if output:
-        audio.export(output, format=output.rsplit(".", 1)[-1])
+        format = output.rsplit(".", 1)[-1]
+        bitrate = "160k" if format == "mp3" else None  # we get 160k from the API
+        audio.export(output, format=format, bitrate=bitrate)
 
 
 @click.command()


### PR DESCRIPTION
By default, ffmpeg uses 32k as its bitrate when exporting to mp3. This is the lowest possible setting and results in bad audio quality.

This PR explicitly sets the bitrate to use when the export format is mp3. We use 160k, which is an unusual choice, but this is what we receive from the API.

There's still going to be some quality loss due to the fact that we decode the audio from mp3 and then encode it back again, but that loss is much less significant than what we had before, and might not even be perceptible.