### PR TITLE
doc: replace macos install command with immediately runnable one

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Install this tool using `pipx`:
 pipx install ospeak
 ```
 Note, on MacOS there's a [broken dependency](https://github.com/simonw/ospeak/issues/4) with Python 3.12 so instead run:
-```bash 
-pipx install --python /path/to/python3.11 ospeak
+```bash
+pipx install --python 3.11 ospeak
 ```
 
 This tool also depends on `ffmpeg`. You can install that on macOS using [Homebrew](https://brew.sh/) like this:


### PR DESCRIPTION
The following should work for most people (at least it did for me) and saves command line editing need.

From `pipx --help`:

```
--python PYTHON       Python to install with. Possible values can be the executable name (python3.11), the version of an available system
                        Python or to pass to py launcher (3.11), or the full path to the executable. Requires Python 3.8 or above.
```