### PR TITLE
Support long inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 .pytest_cache
 *.egg-info
 .DS_Store
+.hypothesis/

--- a/ospeak/cli.py
+++ b/ospeak/cli.py
@@ -13,6 +13,7 @@ VOICES = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
 # OpenAI's TTS API has a limit of 4096 characters per request
 MAX_CHARS = 4096
 
+
 def generate_audio_chunk(client, model, voice, speed, text):
     try:
         response = client.audio.speech.create(
@@ -31,15 +32,17 @@ def generate_audio_chunk(client, model, voice, speed, text):
     byte_stream = io.BytesIO(response.content)
     return AudioSegment.from_file(byte_stream, format="mp3")
 
+
 def generate_audio(api_key, model, voice, speed, text):
     client = OpenAI(api_key=api_key)
 
     text_chunks = text_splitter(text, chunk_size=MAX_CHARS)
     if len(text_chunks) > 1:
-        print(f'Splitting text into {len(text_chunks)} chunks', file=sys.stderr)
+        print(f"Splitting text into {len(text_chunks)} chunks", file=sys.stderr)
 
     for text_chunk in text_chunks:
         yield generate_audio_chunk(client, model, voice, speed, text_chunk)
+
 
 def stream_and_play(
     text, voice="alloy", model="tts-1", speed=1.0, speak=True, api_key=None, output=None

--- a/ospeak/splitter.py
+++ b/ospeak/splitter.py
@@ -1,36 +1,36 @@
 from typing import List, Optional
 
+SEPARATORS = ["\n\n", "\n", ". ", " "]
+
 
 def text_splitter(
     text: str,
     separators: Optional[List[str]] = None,
     chunk_size: int = 1000,
 ) -> List[str]:
-    separators = separators or ["\n\n", "\n", ". ", " "]
+    separators = separators or SEPARATORS
 
-    result = recursive_split(text, separators, chunk_size)
-
-    return [chunk.strip() for chunk in result]
+    return list(recursive_split(text, separators, chunk_size))
 
 
-def recursive_split(text: str, separators: List[str], chunk_size):
+def recursive_split(text: str, separators: List[str], chunk_size: int):
     if not separators:
         yield text
         return
 
     separator = separators[0]
     chunks = split_text(text, separator)
-
     current_chunk = ""
 
     for chunk in chunks:
-        if len(current_chunk) + len(chunk) > chunk_size and current_chunk:
+        # If adding chunk would exceed size limit, yield what we have
+        if current_chunk and len(current_chunk) + len(chunk) > chunk_size:
             yield current_chunk
             current_chunk = ""
 
-        sub_chunks = recursive_split(chunk, separators[1:], chunk_size)
-        for sub_chunk in sub_chunks:
-            if len(current_chunk) + len(sub_chunk) > chunk_size and current_chunk:
+        # Recursively split the chunk
+        for sub_chunk in recursive_split(chunk, separators[1:], chunk_size):
+            if len(current_chunk) + len(sub_chunk) > chunk_size:
                 yield current_chunk
                 current_chunk = ""
             current_chunk += sub_chunk
@@ -42,7 +42,6 @@ def recursive_split(text: str, separators: List[str], chunk_size):
 def split_text(text: str, separator: str) -> List[str]:
     chunks = text.split(separator)
     return [
-        chunk.strip() + (separator if i < len(chunks) else '')
+        chunk + (separator if i < len(chunks) else "")
         for i, chunk in enumerate(chunks, 1)
-        if chunk.strip()
     ]

--- a/ospeak/splitter.py
+++ b/ospeak/splitter.py
@@ -1,0 +1,48 @@
+from typing import List, Optional
+
+
+def text_splitter(
+    text: str,
+    separators: Optional[List[str]] = None,
+    chunk_size: int = 1000,
+) -> List[str]:
+    separators = separators or ["\n\n", "\n", ". ", " "]
+
+    result = recursive_split(text, separators, chunk_size)
+
+    return [chunk.strip() for chunk in result]
+
+
+def recursive_split(text: str, separators: List[str], chunk_size):
+    if not separators:
+        yield text
+        return
+
+    separator = separators[0]
+    chunks = split_text(text, separator)
+
+    current_chunk = ""
+
+    for chunk in chunks:
+        if len(current_chunk) + len(chunk) > chunk_size and current_chunk:
+            yield current_chunk
+            current_chunk = ""
+
+        sub_chunks = recursive_split(chunk, separators[1:], chunk_size)
+        for sub_chunk in sub_chunks:
+            if len(current_chunk) + len(sub_chunk) > chunk_size and current_chunk:
+                yield current_chunk
+                current_chunk = ""
+            current_chunk += sub_chunk
+
+    if current_chunk:
+        yield current_chunk
+
+
+def split_text(text: str, separator: str) -> List[str]:
+    chunks = text.split(separator)
+    return [
+        chunk.strip() + (separator if i < len(chunks) else '')
+        for i, chunk in enumerate(chunks, 1)
+        if chunk.strip()
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ CI = "https://github.com/simonw/ospeak/actions"
 ospeak = "ospeak.cli:cli"
 
 [project.optional-dependencies]
-test = ["pytest", "cogapp"]
+test = ["pytest", "cogapp", "hypothesis"]
 
 [tool.ruff.lint]
 # Enable the isort rules.

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,82 @@
+from ospeak.splitter import text_splitter
+
+
+def test_default_separators():
+    text = "Hello\n\nWorld\nHow are you?"
+    result = text_splitter(text, chunk_size=12)
+    expected = ["Hello", "World", "How are you?"]
+    assert result == expected
+
+
+def test_custom_separators():
+    text = "apple,banana;cherry"
+    result = text_splitter(text, separators=[",", ";"], chunk_size=12)
+    expected = ["apple,", "banana;", "cherry"]
+    assert result == expected
+
+
+def test_empty_text():
+    text = ""
+    result = text_splitter(text)
+    expected = []
+    assert result == expected
+
+
+def test_no_splits():
+    text = "HelloWorld"
+    result = text_splitter(text, separators=[","])
+    expected = ["HelloWorld"]
+    assert result == expected
+
+
+def test_split_sentences_short_first():
+    text = (
+        "Sure. This is a long text that should be split into smaller chunks based"
+        " on the specified chunk size."
+    )
+    result = text_splitter(text, chunk_size=20)
+    assert result == [
+        'Sure.',
+        'This is a long text',
+        'that should be',
+        'split into smaller',
+        'chunks based on the',
+        'specified chunk',
+        'size.',
+    ]
+
+
+def test_split_sentences_short_second():
+    text = (
+        "This is a long text that should be split into smaller chunks based"
+        " on the specified chunk size. Sure."
+    )
+    result = text_splitter(text, chunk_size=20)
+    assert result == [
+        'This is a long text',
+        'that should be',
+        'split into smaller',
+        'chunks based on the',
+        'specified chunk',
+        'size. Sure.',
+    ]
+
+
+def test_multiple_separators():
+    text = "Hello,World;How:are you?"
+    result = text_splitter(text, separators=[",", ";", ":"], chunk_size=8)
+    expected = ["Hello,", "World;", "How:", "are you?"]
+    assert result == expected
+
+
+def test_nested_splitting():
+    text = "Chapter 1\n\nParagraph 1.\nParagraph 2.\n\nChapter 2\n\nParagraph 3."
+    result = text_splitter(text, chunk_size=20)
+    expected = [
+        "Chapter 1",
+        "Paragraph 1.",
+        "Paragraph 2.",
+        "Chapter 2",
+        "Paragraph 3.",
+    ]
+    assert result == expected


### PR DESCRIPTION
As the OpenAI [Create speech docs](https://platform.openai.com/docs/api-reference/audio/createSpeech#audio-createspeech-input) mention:
> `input`
> The text to generate audio for. The maximum length is 4096 characters

This PR splits the input text up into chunks, each less than 4096 characters. It tries to split by paragraph and sentence where possible.